### PR TITLE
publishing: Allow setting target format

### DIFF
--- a/src/commands/publishDocument.ts
+++ b/src/commands/publishDocument.ts
@@ -1,5 +1,6 @@
 import { Notice, TFile } from "obsidian";
 import type AtmospherePlugin from "../main";
+import type { ContentFormat } from "../settings";
 import { createDocument, putDocument, getPublication, markdownToLeafletContent, stripMarkdown, markdownToPcktContent, buildDocumentUrl, resolveWikilinks } from "../lib";
 import { PublicationSelection, SelectPublicationModal } from "../components/selectPublicationModal";
 import { type ResourceUri, } from "@atcute/lexicons";
@@ -87,6 +88,17 @@ async function updateFrontMatter(
 	});
 }
 
+function normalizeFormat(raw: unknown): ContentFormat | undefined {
+	if (typeof raw !== "string") {
+		return undefined;
+	}
+	const trimmed = raw.trim().toLowerCase();
+	if (trimmed === "leaflet" || trimmed === "pckt" || trimmed === "plaintext") {
+		return trimmed;
+	}
+	return undefined;
+}
+
 
 async function buildDocumentRecord(plugin: AtmospherePlugin, file: TFile): Promise<{ record: SiteStandardDocument.Main; docUri?: ResourceUri }> {
 	const full = await plugin.app.vault.read(file);
@@ -105,6 +117,7 @@ async function buildDocumentRecord(plugin: AtmospherePlugin, file: TFile): Promi
 	let path: string | undefined;
 	let tags: string[] | undefined;
 	let publishedAt: string | undefined;
+	let format: ContentFormat | undefined;
 	if (fm) {
 		pubUri = fm["atPublication"];
 		docUri = fm["atDocument"] as ResourceUri;
@@ -114,6 +127,7 @@ async function buildDocumentRecord(plugin: AtmospherePlugin, file: TFile): Promi
 		tags = fm["tags"] && Array.isArray(fm["tags"]) ? fm["tags"] : undefined;
 		publishedAt = fm["publishedAt"]; // Preserve existing if updating
 	}
+	format = normalizeFormat(fm?.["format"]);
 
 	if (!title && plugin.settings.publish.useFirstHeaderAsTitle) {
 		title = extractFirstH1(content);
@@ -144,10 +158,20 @@ async function buildDocumentRecord(plugin: AtmospherePlugin, file: TFile): Promi
 	let textContent = stripMarkdown(resolved);
 
 	let richContent: PubLeafletContent.Main | BlogPcktContent.Main | null = null;
+	const publicationFormat = pubUri ? normalizeFormat(plugin.settings.publicationFormats?.[pubUri]) : undefined;
+	let contentFormat: ContentFormat = "plaintext";
 	if (pub?.url.contains("leaflet.pub")) {
-		richContent = await markdownToLeafletContent(resolved)
+		contentFormat = "leaflet";
 	} else if (pub?.url.contains("pckt.blog")) {
-		richContent = markdownToPcktContent(resolved)
+		contentFormat = "pckt";
+	} else {
+		contentFormat = format ?? publicationFormat ?? "plaintext";
+	}
+
+	if (contentFormat === "leaflet") {
+		richContent = await markdownToLeafletContent(resolved);
+	} else if (contentFormat === "pckt") {
+		richContent = markdownToPcktContent(resolved);
 	}
 
 	let record = {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,7 +14,10 @@ export interface AtProtoSettings {
 	publish: {
 		useFirstHeaderAsTitle: boolean;
 	};
+	publicationFormats: Record<string, ContentFormat>;
 }
+
+export type ContentFormat = "leaflet" | "pckt" | "plaintext";
 
 export const DEFAULT_SETTINGS: AtProtoSettings = {
 	clipDir: "AtmosphereClips",
@@ -24,6 +27,7 @@ export const DEFAULT_SETTINGS: AtProtoSettings = {
 	publish: {
 		useFirstHeaderAsTitle: false,
 	},
+	publicationFormats: {},
 };
 
 export class SettingTab extends PluginSettingTab {
@@ -164,5 +168,6 @@ export class SettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					})
 			);
+
 	}
 }


### PR DESCRIPTION
Adds the ability to choose a default publishing format (currently users can choose between Leaflet.pub, Pckt.blog, or plaintext), as well as adding a per-note override via the `format` frontmatter field.