### PR TITLE
standard.site: Respect `path` field and normalize URLs

### DIFF
--- a/src/commands/publishDocument.ts
+++ b/src/commands/publishDocument.ts
@@ -43,6 +43,18 @@ export async function publishFileAsDocument(plugin: AtmospherePlugin) {
 	}
 }
 
+function normalizePath(raw: unknown): string | undefined {
+	if (typeof raw !== "string") {
+		return undefined;
+	}
+	const trimmed = raw.trim();
+	if (!trimmed) {
+		return undefined;
+	}
+	const withoutLeading = trimmed.replace(/^\/+/, "");
+	return withoutLeading || undefined;
+}
+
 async function updateFrontMatter(
 	plugin: AtmospherePlugin,
 	file: TFile,
@@ -97,6 +109,7 @@ async function buildDocumentRecord(plugin: AtmospherePlugin, file: TFile): Promi
 		docUri = fm["atDocument"] as ResourceUri;
 		description = fm["description"];
 		title = fm["title"];
+		path = normalizePath(fm["path"]);
 		tags = fm["tags"] && Array.isArray(fm["tags"]) ? fm["tags"] : undefined;
 		publishedAt = fm["publishedAt"]; // Preserve existing if updating
 	}

--- a/src/lib/standardsite/index.ts
+++ b/src/lib/standardsite/index.ts
@@ -21,7 +21,8 @@ export function buildDocumentUrl(pubUrl: string, docUri: string, record: SiteSta
 		return ""
 	}
 
-	return `${baseUrl}/${record.path}`
+	const normalizedPath = record.path.replace(/^\/+/, "");
+	return `${baseUrl}/${normalizedPath}`
 }
 
 
@@ -211,4 +212,3 @@ export async function getSubscribedPublications(client: Client, repo: string): P
 	}
 	return pubs;
 }
-


### PR DESCRIPTION
The `path` frontmatter field in notes being published is now passed on to the resultant `site.standard.document` record, and the `url` field written post-publish now uses that path and is sanitized to prevent double slashes.